### PR TITLE
fix(bar): let the native menu bar reveal above the bar

### DIFF
--- a/helper/bar.swift
+++ b/helper/bar.swift
@@ -2622,7 +2622,13 @@ func pointerAtScreenTop() {
     else { return }
     let fromTop = screen.frame.maxY - p.y
     if fromTop <= revealEdge {
-        setRevealed(true)
+        // Climb only when fullscreen actually hides the bar. Otherwise stay
+        // at the -20 resting level so the auto-hidden native menu bar can
+        // slide in ABOVE the bar and stay clickable — app menus are
+        // unreachable by mouse without this.
+        if fullscreenDisplays().contains(screenID(screen)) {
+            setRevealed(true)
+        }
     } else if revealed, openPopup == nil, fromTop > barHeight + 12 {
         // a popup keeps it up: its anchor must not vanish under the pointer
         setRevealed(false)


### PR DESCRIPTION
## Problem

With the native menu bar auto-hidden (as `macos-defaults.sh` sets up), app menus become unreachable:

- Pushing the pointer to the top edge is exactly the gesture that reveals the hidden native menu bar — but it is also the bar's fullscreen-reveal trigger, which raises the bar to level 1002 unconditionally. The menu bar slides in **underneath** the omacosy bar and cannot be clicked.
- Keyboard reveals (`Ctrl+F2`, `Cmd+?` Help search) surface the menu bar the same way, so they are covered too.

Net effect: File/Edit/View/… of the focused app (anything not covered by a command palette) cannot be reached at all.

## Fix

The climb to 1002 is only needed when a fullscreen window actually hides the bar — the watch-a-film case the reveal comment describes. This gates `setRevealed(true)` on `fullscreenDisplays()` containing the pointed screen.

In normal use the bar now stays at its resting −20 (below `NSWindow.Level.mainMenu`), so the revealed native menu bar draws above it and stays clickable, then tucks away as usual. Fullscreen behavior is unchanged: the bar still climbs above the shroud and the fullscreen window when the pointer asks for it.

Tested on macOS 26.5.2 with AeroSpace: menu bar reveal works by mouse and keyboard, fullscreen reveal still works, popups unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7r7mv8DoDVfivUf7RLs36
