### PR TITLE
feat(bar): support custom workspace icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,38 @@ clickable (app menus were unreachable before that fix). It drops back
 behind everything when the pointer leaves. Under OmniWM the bar simply
 stays visible in its reserved strip and never plays this game.
 
+### Workspace icons
+
+You can set workspace icons in the optional
+`~/.config/omacosy/workspace-icons.conf` file. Each non-comment line has one
+workspace name, an equals sign, and either one Unicode scalar or a reverse-DNS
+application bundle identifier.
+
+```
+1 = ★
+14 = ◆
+
+4 = com.apple.Safari
+```
+
+The bar first uses a configured icon. It then uses the icon of the sole app on
+that workspace, and finally shows the workspace's last digit. Exact workspace
+names win. In this example, workspace `14` uses `◆`, not the `4` shorthand.
+The shorthand applies only to multi-digit, all-numeric workspace names ending
+in `1` through `9` when they have no valid exact declaration.
+
+The bar reads the file once at startup. To apply an edit, restart it with:
+
+```sh
+launchctl kickstart -k "gui/$(id -u)/com.omacosy.bar"
+```
+
+Malformed lines are logged and ignored. A well-formed bundle identifier that
+does not resolve to an installed app is unavailable. It blocks shorthand for
+that exact workspace, then the bar falls back to the sole app or the digit.
+Image paths are unsupported because the bar resolves configured app icons at
+startup and does no config-file or image-file I/O while it draws.
+
 - **Apple menu**: About, System Settings, Lock, Sleep, Restart, Shut
   Down, Next Theme (the menu the hidden native bar took away).
 - **Workspaces**: one segmented capsule per monitor showing only that

--- a/helper/bar.swift
+++ b/helper/bar.swift
@@ -176,6 +176,122 @@ func tlog(_ m: String) {
     }
 }
 
+private struct BundleIdentifier {
+    let rawValue: String
+
+    init?(_ rawValue: String) {
+        let segments = rawValue.split(separator: ".", omittingEmptySubsequences: false)
+        guard segments.count >= 2,
+              segments.allSatisfy({ segment in
+                  guard let first = segment.unicodeScalars.first,
+                        BundleIdentifier.isAlphanumeric(first) else { return false }
+                  return segment.unicodeScalars.allSatisfy(BundleIdentifier.isAlphanumericOrHyphen)
+              })
+        else { return nil }
+        self.rawValue = rawValue
+    }
+
+    private static func isAlphanumeric(_ scalar: UnicodeScalar) -> Bool {
+        (48...57).contains(scalar.value) || (65...90).contains(scalar.value)
+            || (97...122).contains(scalar.value)
+    }
+
+    private static func isAlphanumericOrHyphen(_ scalar: UnicodeScalar) -> Bool {
+        isAlphanumeric(scalar) || scalar.value == 45
+    }
+}
+
+private enum WorkspaceIcon {
+    case glyph(String)
+    case image(NSImage)
+    case unavailable
+}
+
+private enum WorkspaceIconDeclaration {
+    case glyph(String)
+    case bundle(BundleIdentifier)
+}
+
+private struct WorkspaceIconConfig {
+    let values: [String: WorkspaceIcon]
+
+    func icon(for workspace: String) -> WorkspaceIcon? {
+        if let icon = values[workspace] { return icon }
+        guard workspace.count > 1,
+              workspace.unicodeScalars.allSatisfy({ (48...57).contains($0.value) }),
+              let last = workspace.unicodeScalars.last,
+              (49...57).contains(last.value)
+        else { return nil }
+        return values[String(Character(last))]
+    }
+}
+
+private func loadWorkspaceIconConfig() -> WorkspaceIconConfig {
+    let file = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".config/omacosy/workspace-icons.conf")
+    guard FileManager.default.fileExists(atPath: file.path) else {
+        return WorkspaceIconConfig(values: [:])
+    }
+    guard let text = try? String(contentsOf: file, encoding: .utf8) else {
+        tlog("workspace-icons: could not read \(file.path)")
+        return WorkspaceIconConfig(values: [:])
+    }
+
+    var declarations: [String: WorkspaceIconDeclaration] = [:]
+    for (offset, rawLine) in text.split(separator: "\n", omittingEmptySubsequences: false).enumerated() {
+        let lineNumber = offset + 1
+        let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !line.isEmpty, !line.hasPrefix("#") else { continue }
+        guard line.filter({ $0 == "=" }).count == 1 else {
+            tlog("workspace-icons: malformed line \(lineNumber)")
+            continue
+        }
+        let parts = line.split(separator: "=", omittingEmptySubsequences: false)
+        let key = String(parts[0]).trimmingCharacters(in: .whitespacesAndNewlines)
+        let value = String(parts[1]).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !key.isEmpty, !value.isEmpty else {
+            tlog("workspace-icons: malformed line \(lineNumber)")
+            continue
+        }
+
+        let declaration: WorkspaceIconDeclaration?
+        if let bundle = BundleIdentifier(value) {
+            declaration = .bundle(bundle)
+        } else if value.unicodeScalars.count == 1,
+                  !value.contains("/") {
+            declaration = .glyph(value)
+        } else {
+            declaration = nil
+        }
+        guard let declaration else {
+            tlog("workspace-icons: malformed line \(lineNumber)")
+            continue
+        }
+        if declarations[key] != nil {
+            tlog("workspace-icons: duplicate \(key) on line \(lineNumber), last valid value wins")
+        }
+        declarations[key] = declaration
+    }
+
+    var values: [String: WorkspaceIcon] = [:]
+    for (key, declaration) in declarations {
+        switch declaration {
+        case .glyph(let glyph):
+            values[key] = .glyph(glyph)
+        case .bundle(let identifier):
+            guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: identifier.rawValue) else {
+                tlog("workspace-icons: \(key) could not resolve \(identifier.rawValue)")
+                values[key] = .unavailable
+                continue
+            }
+            values[key] = .image(NSWorkspace.shared.icon(forFile: url.path))
+        }
+    }
+    return WorkspaceIconConfig(values: values)
+}
+
+private let workspaceIconConfig = loadWorkspaceIconConfig()
+
 // --- theme ----------------------------------------------------------------
 // The same palette sketchybar reads. Parsed once and kept as colours, not
 // re-sourced per item by sixteen shell scripts.
@@ -2221,13 +2337,17 @@ final class BarView: NSView {
                 NSBezierPath(roundedRect: pill, xRadius: radius, yRadius: radius).fill()
             }
             let tint: NSColor = ws == surface.visible ? palette.barBG : palette.muted
-            // a workspace holding exactly one app shows that app's icon —
-            // free here, where NSRunningApplication hands the icon over,
-            // versus sketchybar's image-registration dance
-            if let app = model.soleApp[ws], let icon = appIcon(app) {
+            switch workspaceIconConfig.icon(for: ws) {
+            case .some(.glyph(let glyph)):
+                drawIcon(glyph, iconFont, tint, centeredIn: box)
+            case .some(.image(let icon)):
                 icon.draw(in: NSRect(x: box.midX - 9, y: barHeight / 2 - 9, width: 18, height: 18))
-            } else {
-                draw(String(ws.suffix(1)), chipFont, tint, centeredIn: box)
+            case .some(.unavailable), .none:
+                if let app = model.soleApp[ws], let icon = appIcon(app) {
+                    icon.draw(in: NSRect(x: box.midX - 9, y: barHeight / 2 - 9, width: 18, height: 18))
+                } else {
+                    draw(String(ws.suffix(1)), chipFont, tint, centeredIn: box)
+                }
             }
             chipRects.append((ws, slot))
             x += chipBox + chipPad * 2

--- a/helper/bar.swift
+++ b/helper/bar.swift
@@ -242,13 +242,12 @@ private func loadWorkspaceIconConfig() -> WorkspaceIconConfig {
         let lineNumber = offset + 1
         let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !line.isEmpty, !line.hasPrefix("#") else { continue }
-        guard line.filter({ $0 == "=" }).count == 1 else {
+        guard let separator = line.firstIndex(of: "=") else {
             tlog("workspace-icons: malformed line \(lineNumber)")
             continue
         }
-        let parts = line.split(separator: "=", omittingEmptySubsequences: false)
-        let key = String(parts[0]).trimmingCharacters(in: .whitespacesAndNewlines)
-        let value = String(parts[1]).trimmingCharacters(in: .whitespacesAndNewlines)
+        let key = String(line[..<separator]).trimmingCharacters(in: .whitespacesAndNewlines)
+        let value = String(line[line.index(after: separator)...]).trimmingCharacters(in: .whitespacesAndNewlines)
         guard !key.isEmpty, !value.isEmpty else {
             tlog("workspace-icons: malformed line \(lineNumber)")
             continue
@@ -257,8 +256,7 @@ private func loadWorkspaceIconConfig() -> WorkspaceIconConfig {
         let declaration: WorkspaceIconDeclaration?
         if let bundle = BundleIdentifier(value) {
             declaration = .bundle(bundle)
-        } else if value.unicodeScalars.count == 1,
-                  !value.contains("/") {
+        } else if value.unicodeScalars.count == 1 {
             declaration = .glyph(value)
         } else {
             declaration = nil

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -59,7 +59,8 @@ rm -rf "/tmp/omacosy-spawn-$(id -u).lock.d"
 rm -f "$HOME/.config/omacosy/ffm-ignore" \
   "$HOME/.config/omacosy/borders.conf" \
   "$HOME/.config/omacosy/apps.conf" \
-  "$HOME/.config/omacosy/gesture.json"
+  "$HOME/.config/omacosy/gesture.json" \
+  "$HOME/.config/omacosy/disabled"
 rmdir "$HOME/.config/omacosy" 2>/dev/null || true
 
 # omacosy-gesture (and the aerospace-swipe era before it: its agent,

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -56,7 +56,11 @@ rm -f /tmp/omacosy-*.log /tmp/omacosy-*.err "/tmp/omacosy-overview-$(id -u).pid"
   /tmp/omacosy-bar-ws /tmp/omacosy-bar-moved /tmp/omacosy-bar-cheatsheet \
   "${TMPDIR:-/tmp}/omacosy-monitor-count"
 rm -rf "/tmp/omacosy-spawn-$(id -u).lock.d"
-rm -rf "$HOME/.config/omacosy"
+rm -f "$HOME/.config/omacosy/ffm-ignore" \
+  "$HOME/.config/omacosy/borders.conf" \
+  "$HOME/.config/omacosy/apps.conf" \
+  "$HOME/.config/omacosy/gesture.json"
+rmdir "$HOME/.config/omacosy" 2>/dev/null || true
 
 # omacosy-gesture (and the aerospace-swipe era before it: its agent,
 # and its clone ONLY if we made it — a pre-existing install stays)


### PR DESCRIPTION
## Why

Workspaces currently lose their semantic icon when they are empty or contain more than one app. This adds the optional startup-loaded mapping discussed in #4 without putting file access or application lookup on the draw path.

## Scope

- Read `~/.config/omacosy/workspace-icons.conf` as `workspace=value` entries.
- Support one-scalar Nerd Font glyphs and installed application bundle identifiers.
- Prefer exact workspace names, then single-digit shorthand for multi-display numeric workspaces.
- Keep the existing sole-app icon and workspace-number fallbacks.
- Preserve user-authored files under `~/.config/omacosy` during uninstall.
- Document configuration, precedence, diagnostics, and restart behavior.

## Tradeoffs

The bar reads this configuration only at startup. Applying an edit requires restarting the launch agent, which avoids a file watcher and keeps rendering event-driven.

## Blast Radius

The runtime change is limited to workspace-chip content selection in `helper/bar.swift`. `install.sh` does not create or overwrite the optional file. `uninstall.sh` now removes only installer-owned files before attempting to remove the config directory.

## Verification

- Production-equivalent optimized Swift build with the linked private frameworks and embedded Info.plist.
- `/bin/bash -n uninstall.sh`.
- `git diff --check origin/main...HEAD`.
- Live stacked-bar run on macOS verified configured glyphs, bundle icons, duplicate handling, malformed-line diagnostics, and unavailable-bundle fallback before the follow-up parser edge-case commit.
- The final head was rebuilt after the parser and uninstall edge-case commit.

Closes #4
