### PR TITLE
fix(update): ignore generated app bundles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .DS_Store
 *.bak.*
+/omacosy-bar.app/
+/omacosy-gesture.app/
 config/apps.local.conf
 config/aerospace/aerospace.toml


### PR DESCRIPTION
## Why

A normal `install.sh` run creates `omacosy-bar.app` and `omacosy-gesture.app` at the repository root. Without tracked ignore rules, those runtime bundles make `git status --porcelain` non-empty. `bin/omacosy-update` then rejects the clone as locally modified.

## Scope

`.gitignore` now ignores `/omacosy-bar.app/` and `/omacosy-gesture.app/`. The root anchors keep app bundles elsewhere visible to Git. No generated bundle contents are committed.

## Tradeoffs

The rules name the two installer outputs instead of ignoring every `*.app` directory. Future generated bundles need an explicit rule.

## Blast Radius

The change affects Git status for two installer-generated directories at the repository root. The runtime bundles stay on disk and continue to serve the menu bar and gesture helpers.

## Verification

- Removed the matching local exclude rules and confirmed that both bundles appeared as untracked files. `bin/omacosy-update` exited with status 1.
- Applied the tracked `.gitignore` from this branch against the installed clone. `git check-ignore -v` resolved both bundle executables to `.gitignore` lines 3 and 4.
- Confirmed that `git status --porcelain` was empty while both bundle executables remained present and executable.
- Confirmed that commit `9d0b33c` changes only `.gitignore`.
