### PR TITLE
fix(bar): schedule clock on every minute boundary

### DIFF
--- a/helper/bar.swift
+++ b/helper/bar.swift
@@ -3560,8 +3560,8 @@ for event in [NSWorkspace.didLaunchApplicationNotification,
 func scheduleClock() {
     updateClock()
     let now = Date()
-    let nextMinute = Calendar.current.date(bySetting: .second, value: 0,
-                                           of: now.addingTimeInterval(60)) ?? now.addingTimeInterval(60)
+    let nextMinute = Calendar.current.nextDate(after: now, matching: DateComponents(second: 0),
+                                               matchingPolicy: .nextTime) ?? now.addingTimeInterval(60)
     DispatchQueue.main.asyncAfter(deadline: .now() + max(1, nextMinute.timeIntervalSinceNow)) { scheduleClock() }
 }
 scheduleClock()


### PR DESCRIPTION
## Why

The bar clock could remain one minute behind and sometimes skip an entire minute.

`scheduleClock()` added 60 seconds before calling `Calendar.date(bySetting: .second, value: 0, of:)`. When a callback ran after second zero — for example at `12:01:01.200` — Calendar searched forward from `12:02:01.200` and returned `12:03:00`, skipping the `12:02` update.

Observed diagnostics showed `11:11, 11:12, 11:14, 11:16` and later `12:01, 12:03`.

## Scope

- Ask Calendar directly for the next minute boundary with `nextDate(after:matching:matchingPolicy:)`.
- Keep the existing fallback and recursive event-driven scheduling.
- Add no polling, dependency, or new timer.

## Tradeoffs

A blocked main queue can still render a tick late, but the next schedule now targets the nearest future minute instead of potentially skipping another one. Calendar continues to own timezone and DST behavior.

## Blast Radius

Only the bar clock's next-fire calculation changes. Weather, media, workspace events, rendering, and other publishers are untouched.

## Verification

- Production-source typecheck passed:
  `swiftc -typecheck -F /System/Library/PrivateFrameworks -framework SkyLight -framework DisplayServices helper/bar.swift`
  (one unrelated pre-existing `fullPath(forApplication:)` deprecation warning).
- Focused Swift reproduction:
  - old calculation at `12:01:01.200` → `12:03:00.000`
  - new calculation → `12:02:00.000`
- `git diff --check` passed.
- Tested on macOS 26.5.2, Europe/Bratislava timezone.