### PR TITLE
fix(ghostty): no size badge on every tiling resize

### DIFF
--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -15,6 +15,16 @@ macos-titlebar-style = hidden
 window-width = 100
 window-height = 30
 
+# ...and because that pinned size is not the tile, the WM resizes every
+# new window the moment it appears. Ghostty's default `after-first`
+# suppresses the size badge only on creation and shows it for any resize
+# AFTER that, so the tiling resize qualified — and so did every re-tile
+# when a sibling window opened or closed. The result was "NNxMM" in the
+# middle of the window for 750 ms, over and over. A compositor never
+# trips this, because it sizes the window before mapping it; an
+# Accessibility-API tiler always does.
+resize-overlay = never
+
 # Every Super+Enter opens a NEW Ghostty instance (`open -na` — one app
 # per window, which is what makes each window a first-class tile).
 # Without this, closing the window leaves its windowless instance


### PR DESCRIPTION
Every new window flashed a `NNxMM` size badge in its middle for 750 ms, and flashed it again on every re-tile when a sibling window opened or closed.

Ghostty's default is `resize-overlay = after-first`, which per its docs "will not appear when the surface is first created, but will show up if the surface is subsequently resized". Both WM paths here create the window at the `window-width`/`window-height` pinned just above and then resize it into its tile — that is a resize after creation, so the badge fires. A compositor like Hyprland never trips it, because the window is sized before it is ever mapped; an Accessibility-API tiler resizes after the fact by construction, so under omacosy the overlay can only ever be noise.

Tested on macOS 26.6.2 (25G83), single display, AeroSpace: `ghostty +validate-config` clean, badge gone on spawn and on re-tile, no other visual change. The OmniWM path shares the same cause (windows are resized into their tile after creation) but I do not run OmniWM, so that is reasoned rather than observed.
